### PR TITLE
Set alpha parameter

### DIFF
--- a/lb-recommendation.py
+++ b/lb-recommendation.py
@@ -109,9 +109,10 @@ if __name__ == "__main__":
     bestRank = 0
     bestLambda = -1.0
     bestNumIter = -1
-
+    alpha = 1.0 # controls baseline confidence growth
+    
     for rank, lmbda, numIter in itertools.product(ranks, lambdas, numIters):
-        model = ALS.trainImplicit(training, rank, numIter, lmbda)
+        model = ALS.trainImplicit(training, rank, iterations=numIter, lambda_=lmbda, alpha=alpha)
         validationRmse = compute_rmse(model, validation, numValidation)
         print("==== RMSE (validation) = %f for the model trained with " % validationRmse + \
               "rank = %d, lambda = %.1f, and numIter = %d." % (rank, lmbda, numIter))


### PR DESCRIPTION
Assuming Spark uses a model similar to http://sci-hub.hk/10.1109/icdm.2008.22, alpha controls the rate of increase of confidence in a user liking a certain item (i.e. recording in our case.)

If I understand this correctly, the default pyspark alpha of 0.01 would only add 0.01 pers listen to the confidence that a user likes a certain recording. I'm pretty sure we want frequent listens to be weighed more than this and the default Spark value of 1.0 seems like a good start for now.

The aforementioned paper recommends an alpha of 40 but they're dealing with TV show watch percentages which probably range from around 0.1 to 10 while in our data set recordings may have been listened to hundres of times.