### PR TITLE
Fix the way tables are persisted (and then accessed).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from pyspark import SparkContext
+from pyspark.sql import SparkSession
+
+spark = SparkSession \
+        .builder \
+        .appName("LB recommender") \
+        .getOrCreate()
+
+sc = spark.sparkContext

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,10 @@
+import os
+from setup import spark, sc
+from pyspark.sql import SQLContext
+
+
+def load_listens_df(directory):
+
+    sql_context = SQLContext(sc)
+    listens_df = sql_context.read.format("parquet").load(os.path.join(directory, "listen.parquet"))
+    return listens_df


### PR DESCRIPTION
Added example in `utils.py` for accessing persisted `listens_df`. Saving `DataFrames` as `.parquet` files with table names