### PR TITLE
Delete temporary directories from playground and hdfs

### DIFF
--- a/listenbrainz_spark/data/import_dump.py
+++ b/listenbrainz_spark/data/import_dump.py
@@ -88,6 +88,8 @@ def copy_to_hdfs(archive, threads=8):
                 total_time += time_taken
                 average_time = total_time / file_count
                 print("Total time: %.2f, average time: %.2f" % (total_time, average_time))
+    hdfs_connection.client.delete(tmp_dump_dir, recursive=True)
+    shutil.rmtree(tmp_dump_dir)
 
 
 def main(app_name, archive):


### PR DESCRIPTION
**PROBLEM:**- Temporary directories created to process 'JSON' files have neither been deleted in playground container nor in hdfs. 

**SOLUTION:-** issue commands to delete the directories after data processing is done. 