### PR TITLE
Connect to the local listenbrainz network in development

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -42,3 +42,8 @@ services:
     command: sleep 1000000000
     volumes:
       - ..:/rec:z
+
+networks:
+    default:
+        external:
+            name: listenbrainz_default


### PR DESCRIPTION
This will allow us to connect to the rabbitmq container in the listenbrainz project in development.