### PR TITLE
Improve the process to download apache distribution packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM airdock/oracle-jdk:jdk-8u112
+FROM airdock/oraclejdk:1.8
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,15 @@ RUN apt-get update \
     scala \
     wget \
     net-tools \
-    dnsutils
+    bsdmainutils 
 
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
+COPY docker/apache-download.sh /apache-download.sh
 RUN cd /usr/local && \
-    wget http://apache.rediris.es/spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && \
+    /apache-download.sh spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && \
     tar xzf spark-2.3.1-bin-hadoop2.7.tgz && \
     ln -s spark-2.3.1-bin-hadoop2.7 spark

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,23 +5,24 @@ RUN apt-get update \
     scala \
     wget \
     net-tools \
-    dnsutils
-
-RUN cd /usr/local && \
-    wget http://apache.rediris.es/spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && \
-    tar xzf spark-2.3.1-bin-hadoop2.7.tgz && \
-    ln -s spark-2.3.1-bin-hadoop2.7 spark
-
-RUN apt-get install -y --no-install-recommends \
+    dnsutils \
     python3-dev \
     python3-pip \
     xz-utils \
-    pxz
+    pxz \
+    bsdmainutils
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 RUN mkdir /rec
 WORKDIR /rec
+
+COPY docker/apache-download.sh /rec/apache-download.sh
+RUN cd /usr/local && \
+    /rec/apache-download.sh spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && \
+    tar xzf spark-2.3.1-bin-hadoop2.7.tgz && \
+    ln -s spark-2.3.1-bin-hadoop2.7 spark
+
 COPY requirements.txt /rec/requirements.txt
 RUN pip3 install -r requirements.txt
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM airdock/oracle-jdk:jdk-8u112
+FROM airdock/oraclejdk:1.8
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/Dockerfile.jobs
+++ b/Dockerfile.jobs
@@ -1,4 +1,4 @@
-FROM airdock/oracle-jdk:jdk-8u112
+FROM airdock/oraclejdk:1.8
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/Dockerfile.jobs
+++ b/Dockerfile.jobs
@@ -10,12 +10,8 @@ RUN apt-get update \
     python3-pip \
     xz-utils \
     pxz \
-    vim    # remove this after we're done with debugging
+    bsdmainutils
 
-RUN cd /usr/local && \
-    wget http://apache.rediris.es/spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && \
-    tar xzf spark-2.3.1-bin-hadoop2.7.tgz && \
-    ln -s spark-2.3.1-bin-hadoop2.7 spark
 
 RUN apt-get install -y zip
 
@@ -23,5 +19,12 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 RUN mkdir /rec
 WORKDIR /rec
+
+COPY docker/apache-download.sh /rec/apache-download.sh
+RUN cd /usr/local && \
+    /rec/apache-download.sh spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && \
+    tar xzf spark-2.3.1-bin-hadoop2.7.tgz && \
+    ln -s spark-2.3.1-bin-hadoop2.7 spark
+
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt

--- a/Dockerfile.master
+++ b/Dockerfile.master
@@ -7,17 +7,18 @@ RUN apt-get update \
     net-tools \
     dnsutils \
     python3-dev \
-    python3-pip
-
-RUN cd /usr/local && \
-    wget http://apache.rediris.es/spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && \
-    tar xzf spark-2.3.1-bin-hadoop2.7.tgz && \
-    ln -s spark-2.3.1-bin-hadoop2.7 spark
+    python3-pip \
+    bsdmainutils 
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 RUN mkdir /rec
 WORKDIR /rec
 COPY . /rec
+
+RUN cd /usr/local && \
+    /rec/docker/apache-download.sh spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && \
+    tar xzf spark-2.3.1-bin-hadoop2.7.tgz && \
+    ln -s spark-2.3.1-bin-hadoop2.7 spark
 
 CMD /usr/local/spark/sbin/start-master.sh

--- a/Dockerfile.master
+++ b/Dockerfile.master
@@ -1,4 +1,4 @@
-FROM airdock/oracle-jdk:jdk-8u112
+FROM airdock/oraclejdk:1.8
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM airdock/oracle-jdk:jdk-8u112
+FROM airdock/oraclejdk:1.8
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -6,22 +6,24 @@ RUN apt-get update \
     wget \
     net-tools \
     python3-dev \
-    python3-pip
+    python3-pip \
+    bsdmainutils
 
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-RUN cd /usr/local && \
-    wget http://apache.rediris.es/spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && \
-    tar xzf spark-2.3.1-bin-hadoop2.7.tgz && \
-    ln -s spark-2.3.1-bin-hadoop2.7 spark
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 RUN mkdir /rec
 WORKDIR /rec
 COPY . /rec
+
+RUN cd /usr/local && \
+    /rec/docker/apache-download.sh spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz && \
+    tar xzf spark-2.3.1-bin-hadoop2.7.tgz && \
+    ln -s spark-2.3.1-bin-hadoop2.7 spark
 
 CMD dockerize -wait tcp://spark-master:7077 -timeout 9999s /usr/local/spark/sbin/start-slave.sh spark://spark-master:7077

--- a/docker/apache-download.sh
+++ b/docker/apache-download.sh
@@ -12,7 +12,7 @@ REDIRECT_BASE_URL="https://www.apache.org/dyn/closer.cgi?action=download&filenam
 ARCHIVE_BASE_URL="https://archive.apache.org/dist/"
 
 echo "downloading $FILE_PATH from mirror"
-CODE=`wget --server-response -O $FILE_NAME "$REDIRECT_BASE_URL$FILE_PATH" 2>&1 | grep "  HTTP" | tail -1 | colrm 1 11 | colrm 4`
+CODE=`wget --server-response -O $FILE_NAME "$REDIRECT_BASE_URL$FILE_PATH" 2>&1 | tee /dev/fd/2 | grep "  HTTP" | tail -1 | colrm 1 11 | colrm 4`
 if [ "$CODE" = "200" ];
 then
     exit 0;
@@ -25,7 +25,7 @@ fi
 # If this becomes/is possible, please let us know how to do this! 
 
 echo "$FILE_PATH not found on mirror, trying archive: $ARCHIVE_BASE_URL$FILE_PATH"
-CODE=`wget --server-response -O $FILE_NAME "$ARCHIVE_BASE_URL$FILE_PATH" 2>&1 | grep "  HTTP" | tail -1 | colrm 1 11 | colrm 4`
+CODE=`wget --server-response -O $FILE_NAME "$ARCHIVE_BASE_URL$FILE_PATH" 2>&1 | tee /dev/fd/2 | grep "  HTTP" | tail -1 | colrm 1 11 | colrm 4`
 if [ "$CODE" = "200" ];
 then
     exit 0;

--- a/docker/apache-download.sh
+++ b/docker/apache-download.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Apache mirror bullshit download script
+
+if [ "$#" -ne 1 ]; then
+    echo "Argument must be file path to apache download. (e.g. spark/spark-2.3.1/spark-2.3.1-bin-hadoop2.7.tgz )"
+    exit 1
+fi
+
+FILE_PATH=$1 
+FILE_NAME=$(basename $FILE_PATH)
+REDIRECT_BASE_URL="https://www.apache.org/dyn/closer.cgi?action=download&filename="
+ARCHIVE_BASE_URL="https://archive.apache.org/dist/"
+
+echo "downloading $FILE_PATH from mirror"
+CODE=`wget --server-response -O $FILE_NAME "$REDIRECT_BASE_URL$FILE_PATH" 2>&1 | grep "  HTTP" | tail -1 | colrm 1 11 | colrm 4`
+if [ "$CODE" = "200" ];
+then
+    exit 0;
+fi
+
+
+# Dear Apache Software Foundation,
+# At the time that this script was written we could not find a way to find a mirror of an archive. The archive
+# site linked to the mirror resolver for the main mirrors... which do not contain the files we need.
+# If this becomes/is possible, please let us know how to do this! 
+
+echo "$FILE_PATH not found on mirror, trying archive: $ARCHIVE_BASE_URL$FILE_PATH"
+CODE=`wget --server-response -O $FILE_NAME "$ARCHIVE_BASE_URL$FILE_PATH" 2>&1 | grep "  HTTP" | tail -1 | colrm 1 11 | colrm 4`
+if [ "$CODE" = "200" ];
+then
+    exit 0;
+fi
+
+echo "failed to download $FILE_PATH"
+exit 1


### PR DESCRIPTION
The problem is that only the very latest release is available on the mirror, everything else is in the archive. And finding mirrored archives seems... not possible.

This PR attempts to download the file from the mirror and if that fails, it downloads it from the archive.